### PR TITLE
Fix for bug #950287

### DIFF
--- a/js/evernote.js
+++ b/js/evernote.js
@@ -548,8 +548,8 @@ var Evernote = new function() {
                         totalQueueChunks++;
                     }
                 }
+	            self.processQueueList();
             }
-            self.processQueueList();
         });
     };
 
@@ -558,7 +558,10 @@ var Evernote = new function() {
         var queue = null;
         var remainingSyncChunks = queueList.notebooks.length
                                 + queueList.notes.length;
-        var percentage = ((totalQueueChunks - remainingSyncChunks) * 100) / totalQueueChunks;
+        var percentage = 100;
+ 		if (totalQueueChunks > 0) {
+			percentage = ((totalQueueChunks - remainingSyncChunks) * 100) / totalQueueChunks;
+		}
         self.updateProgressBar(percentage);
         if (App.DEBUG) {
             Console.log('this.processQueueList');
@@ -648,6 +651,9 @@ var Evernote = new function() {
                             queue.remove(self.processQueueList);
                         });
                     }
+				} else {
+					// Note not in DB - skip it
+					queue.remove(self.processQueueList);
                 }
             });
         }


### PR DESCRIPTION
1. When sending local changes to Evernote, skip an item in the pending
   queue if it is not found in the local db. This happens when a new note
   is opened and then canceled.
2. When sendChanges is called (to send local changes to Evernote), if
   pending queues are empty, don't start the processing.
3. Variable 'totalQueueChunks', used to compute progress, can be zero.
   Added defensive code to avoid divide by zero error.
