### PR TITLE
Fix for bug #950475

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -668,6 +668,8 @@ var App = new function() {
             });
             el.addEventListener("touchend", function(e){
                 window.clearTimeout(this.timeoutHold);
+            });
+            el.addEventListener("click", function(e){
                 if (!this.edited && !tapIgnored) {
                     clickNotebook(notebook);
                 }


### PR DESCRIPTION
Selection on notebook list was handled by "touchend" event.
The subsequent "click" event was instead sent to the notebook
view which causes a note to be opened.

Change notebook selection to be triggered on "click" instead.
