### PR TITLE
Fix for bug #950968

### DIFF
--- a/style/common.css
+++ b/style/common.css
@@ -836,3 +836,8 @@ progress[role="loading"] {
 body.loading .card:not(.active) {
     display: none;
 }
+
+#note-content img {
+    max-width:100%;
+    height: auto;
+}


### PR DESCRIPTION
Add CSS styling to note view images to auto resize to 100% width.
