### PR TITLE
Fix for bug #957279

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -1288,11 +1288,11 @@ var App = new function() {
 
         this.showSearchTitle = function() {
             elTitle.style.display = "none";
-            elSearchTitle.style.display = "block";
+            elSearchTitle.style.display = "";
         };
 
         this.hideSearchTitle = function() {
-            elTitle.style.display = "block";
+            elTitle.style.display = "";
             elSearchTitle.style.display = "none";
         };
 


### PR DESCRIPTION
Code uses "display: block" and "display: none" to show and hide
search title, causing the "style" to override the CSS class used
to show/hide title during editing.
