### PR TITLE
bug 1009141 - restore "Notes" app name

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -1,7 +1,7 @@
 {
-  "name": "Notes+",
+  "name": "Notes",
   "description": "Notes app",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "launch_path": "/index.html",
   "type": "privileged",
   "redirects": [


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1009141
