### PR TITLE
Added catalan language ('ca') to locales.

### DIFF
--- a/locales/locales.ini
+++ b/locales/locales.ini
@@ -23,3 +23,6 @@
 
 [uk]
 @import url(notes.uk.properties)
+
+[ca]
+@import url(notes.ca.properties)

--- a/locales/notes.ca.properties
+++ b/locales/notes.ca.properties
@@ -1,0 +1,80 @@
+# General note/notebook operations
+notebooks=Blocs de Notes
+tap-anywhere-to-start=Premeu a qualsevol lloc per iniciar
+note-info=Informacio de la nota
+add-to-contacts=Afegir a Contactes
+new-notebook=Crear Bloc de Notes
+notebook-all=Totes les notes
+notebook-trash=Paperera
+notebook-action-title=Editar Bloc de notes
+notebook-action-rename=Canviar el nom
+notebook-action-delete=Eliminar
+prompt-rename-notebook=Canviar el nom del Bloc de notes:
+prompt-delete-notebook=Premeu OK per eliminar aquest Bloc de notes. \n\nOBSERVACI&Oacute;: totes les vostres notes seran enviades a la paperera.
+note-restored=Recuperat a {{notebook}}
+new-note=Nova nota
+empty-trash=La paperera &eacute;s buida!
+first-notebook-name=El meu Bloc de notes
+empty-notebook-name=Notes
+note-cancel-changes=S'han realitzat canvis a la nota, voleu desar els canvis?
+confirm-trash-note=Premeu OK per moure aquesta nota a la Paperera
+confirm-delete-note=Esteu segurs de que voleu eliminar definitivament aquesta nota?
+add-image-title=Annexar una foto a la nota:
+image-not-supported=Aquesta caracter&iacute;stica no est&agrave; suportada en aquest terminal
+image-label=Foto
+date-updated=Data d&#39;actualitzaci&oacute;
+date-created=Data de creaci&oacute;
+title=T&iacute;tol
+notebook=Bloc de notes
+created-on=Creat
+modified-on=Modificat
+done=Fet
+search-results=Resultats de la cerca
+empty-notebook=No hi ha notes guardades<br />Comen&ccedil;ar a escriure ara
+
+# Evernote integration
+connect-with=Connectar amb
+connected-to-evernote=Connectant amb Evernote
+settings=Par&agrave;metres
+signed-in-as=Registrat com 
+account-type=Tipus de compte
+go-premium=Anar a Premium
+sign-out=Sortir
+evernote-email-address=Adre&ccedil;a de correu a Evernote
+current-monthly-usage=&Uacute;s mensual actual
+upload-left=Resta per pujar
+days-left=Dies que resten
+
+# relative elapsed times for indicating age of note
+minutes-ago = {[ plural(t) ]}
+minutes-ago[zero]=Ara mateix
+minutes-ago[one]=Fa 1 minut
+minutes-ago[two]=Fa {{t}} minuts
+minutes-ago[few]=Fa {{t}} minuts
+minutes-ago[many]=Fa {{t}} minuts
+minutes-ago[other]=Fa {{t}} minuts
+
+hours-ago = {[ plural(t) ]}
+hours-ago[zero]=Fa {{t}} hores
+hours-ago[one]=Fa una hora
+hours-ago[two]=Fa {{t}} hores
+hours-ago[few]=Fa {{t}} hores
+hours-ago[many]=Fa {{t}} hores
+hours-ago[other]=Fa {{t}} hores
+
+days-ago = {[ plural(t) ]}
+days-ago[zero]=Fa {{t}} dies
+days-ago[one]=Ahir
+days-ago[two]=Fa {{t}} dies
+days-ago[few]=Fa {{t}} dies
+days-ago[many]=Fa {{t}} dies
+days-ago[other]=Fa {{t}} dies
+
+# Error messages
+notebook-name-already-exists=Ja existeix un Bloc de notes amb aquest nom. Escolliu un altre.
+not-reached-evernote=No ha estat possible connectar amb el servidor d&#39;Evernote. Comproveu la connexi&oacute; a internet del vostre dispositiu.
+notebook-delete-conflict=S'ha eliminat el Bloc de notes local. Voleu recuperar-lo del servidor?
+generic-conflict=A Evernote hi ha una versi&oacute; diferent de la {{object}} {{name}} amb data {{date}}. Voleu conservar els canvis locals?
+note-unsaveable=No es pot editar aquesta nota perqu&egrave; no s&#39;ha baixat completament.
+sync-failed=No s'ha completat la darrera baixada Evernote. Voleu provar un altre cop?
+warning=(Algunes imatges o adjunts pesats no poden ser baixats. La nota &eacute;s nom&eacute;s de lectura.)

--- a/locales/notes.ca.properties
+++ b/locales/notes.ca.properties
@@ -10,7 +10,7 @@ notebook-action-title=Editar Bloc de notes
 notebook-action-rename=Canviar el nom
 notebook-action-delete=Eliminar
 prompt-rename-notebook=Canviar el nom del Bloc de notes:
-prompt-delete-notebook=Premeu OK per eliminar aquest Bloc de notes. \n\nObservaci\u00f3: totes les vostres notes seran enviades a la paperera.
+prompt-delete-notebook=Premeu OK per eliminar aquest Bloc de notes. \n\nObservació: totes les vostres notes seran enviades a la paperera.
 note-restored=Recuperat a {{notebook}}
 new-note=Nova nota
 empty-trash=La paperera &eacute;s buida!
@@ -35,7 +35,7 @@ empty-notebook=No hi ha notes guardades<br />Comen&ccedil;ar a escriure ara
 # Evernote integration
 connect-with=Connectar amb
 connected-to-evernote=Connectant amb Evernote
-settings=Par\u00e0metres
+settings=Paràmetres
 signed-in-as=Registrat com 
 account-type=Tipus de compte
 go-premium=Anar a Premium

--- a/locales/notes.ca.properties
+++ b/locales/notes.ca.properties
@@ -13,24 +13,24 @@ prompt-rename-notebook=Canviar el nom del Bloc de notes:
 prompt-delete-notebook=Premeu OK per eliminar aquest Bloc de notes. \n\nObservació: totes les vostres notes seran enviades a la paperera.
 note-restored=Recuperat a {{notebook}}
 new-note=Nova nota
-empty-trash=La paperera &eacute;s buida!
+empty-trash=La paperera és buida!
 first-notebook-name=El meu Bloc de notes
 empty-notebook-name=Notes
 note-cancel-changes=S'han realitzat canvis a la nota, voleu desar els canvis?
 confirm-trash-note=Premeu OK per moure aquesta nota a la Paperera
 confirm-delete-note=Esteu segurs de que voleu eliminar definitivament aquesta nota?
 add-image-title=Annexar una foto a la nota:
-image-not-supported=Aquesta caracter&iacute;stica no est&agrave; suportada en aquest terminal
+image-not-supported=Aquesta característica no està suportada en aquest terminal
 image-label=Foto
-date-updated=Data d&#39;actualitzaci&oacute;
-date-created=Data de creaci&oacute;
-title=T&iacute;tol
+date-updated=Data d'actualització
+date-created=Data de creació
+title=Títol
 notebook=Bloc de notes
 created-on=Creat
 modified-on=Modificat
 done=Fet
 search-results=Resultats de la cerca
-empty-notebook=No hi ha notes guardades<br />Comen&ccedil;ar a escriure ara
+empty-notebook=No hi ha notes guardades<br />Començar a escriure ara
 
 # Evernote integration
 connect-with=Connectar amb
@@ -40,8 +40,8 @@ signed-in-as=Registrat com
 account-type=Tipus de compte
 go-premium=Anar a Premium
 sign-out=Sortir
-evernote-email-address=Adre&ccedil;a de correu a Evernote
-current-monthly-usage=&Uacute;s mensual actual
+evernote-email-address=Adreça de correu a Evernote
+current-monthly-usage=Ús mensual actual
 upload-left=Resta per pujar
 days-left=Dies que resten
 
@@ -72,9 +72,9 @@ days-ago[other]=Fa {{t}} dies
 
 # Error messages
 notebook-name-already-exists=Ja existeix un Bloc de notes amb aquest nom. Escolliu un altre.
-not-reached-evernote=No ha estat possible connectar amb el servidor d&#39;Evernote. Comproveu la connexi&oacute; a internet del vostre dispositiu.
+not-reached-evernote=No ha estat possible connectar amb el servidor d'Evernote. Comproveu la connexió a internet del vostre dispositiu.
 notebook-delete-conflict=S'ha eliminat el Bloc de notes local. Voleu recuperar-lo del servidor?
-generic-conflict=A Evernote hi ha una versi&oacute; diferent de la {{object}} {{name}} amb data {{date}}. Voleu conservar els canvis locals?
-note-unsaveable=No es pot editar aquesta nota perqu&egrave; no s&#39;ha baixat completament.
+generic-conflict=A Evernote hi ha una versió diferent de la {{object}} {{name}} amb data {{date}}. Voleu conservar els canvis locals?
+note-unsaveable=No es pot editar aquesta nota perquè no s'ha baixat completament.
 sync-failed=No s'ha completat la darrera baixada Evernote. Voleu provar un altre cop?
-warning=(Algunes imatges o adjunts pesats no poden ser baixats. La nota &eacute;s nom&eacute;s de lectura.)
+warning=(Algunes imatges o adjunts pesats no poden ser baixats. La nota és només de lectura.)

--- a/locales/notes.ca.properties
+++ b/locales/notes.ca.properties
@@ -10,7 +10,7 @@ notebook-action-title=Editar Bloc de notes
 notebook-action-rename=Canviar el nom
 notebook-action-delete=Eliminar
 prompt-rename-notebook=Canviar el nom del Bloc de notes:
-prompt-delete-notebook=Premeu OK per eliminar aquest Bloc de notes. \n\nOBSERVACI&Oacute;: totes les vostres notes seran enviades a la paperera.
+prompt-delete-notebook=Premeu OK per eliminar aquest Bloc de notes. \n\nObservaci\u00f3: totes les vostres notes seran enviades a la paperera.
 note-restored=Recuperat a {{notebook}}
 new-note=Nova nota
 empty-trash=La paperera &eacute;s buida!
@@ -35,7 +35,7 @@ empty-notebook=No hi ha notes guardades<br />Comen&ccedil;ar a escriure ara
 # Evernote integration
 connect-with=Connectar amb
 connected-to-evernote=Connectant amb Evernote
-settings=Par&agrave;metres
+settings=Par\u00e0metres
 signed-in-as=Registrat com 
 account-type=Tipus de compte
 go-premium=Anar a Premium

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -73,6 +73,10 @@
     "uk": {
       "name": "Нотатки",
       "description": "Нотатки - це офіційна програма Firefox OS. Нотатки створено, щоб допомогти зберегти всі ідеї, нагадування та моменти натхнення, тримаючи їх всі на пристрої, яким ви користуєтесь щодня. Маючи доступ до своїх нотаток, ви зможете організувати свій час з найменшими зусиллями."
+    },
+    "ca": {
+      "name": "Notes",
+      "description": "Notes és l'aplicació oficial de Firefox OS. Notes ha estat dissenyada per ajudar a preservar totes aquelles idees, recordatoris i moments d'inspiració, tot mantenint un registre ben accessible justament  al vostre dispositiu d'ús diari. Equipat amb un cercador amb el que podreu trobar-ho tot i amb la possibilitat d'agrupar les vostres notes en blocs diferents, podeu organitzar-vos amb el mínim esforç."
     }
   },
   "default_locale": "en-US"


### PR DESCRIPTION
Indeed, i saw a very rare thing: if you open any .properties file in locales, you can see odd characters in the place of latin characters, typical when you're inserting iso-latin characters into a UTF-8 file. Is it correct?

Instead, for catalan, i used htmlentities. For example, instead of "é" i put "&eacute;". I tested it in the FFX simulator and it's well rendered.

But, i cannot understand why we simply cannot use the character written and coded in utf8, as usual... Someone who really understand these questions can give a good explanation or maybe check the files?

I checked the files and the index.html and all seem to use UYF-8... :|